### PR TITLE
fix buffer overflows in game Reflector and RWheel

### DIFF
--- a/src/games/gameRWheel.c
+++ b/src/games/gameRWheel.c
@@ -9,8 +9,8 @@ CS = {{
           "ll l l",
           "ll l l",
           "llllll",
-          " l  l",
-          " l  l",
+          " l  l ",
+          " l  l ",
       },
       {
           "      ",

--- a/src/games/gameReflector.c
+++ b/src/games/gameReflector.c
@@ -173,7 +173,7 @@ static void update() {
       t->angle += t->angleVel;
     }
     bar(VEC_XY(t->pos), 3, t->angle);
-    char tc[2] = {'c' + (int)(ticks / 25) % 2, '\n'};
+    char tc[2] = {'c' + (int)(ticks / 25) % 2, '\0'};
     characterOptions.isMirrorX = t->vx < 0;
     if (character(tc, VEC_XY(t->pos)).isColliding.rect[LIGHT_RED]) {
       play(POWER_UP);


### PR DESCRIPTION
this fixes the issue #8 and fixes random characters potentially appearing in the reflector game at least on the gcc / mingw64 builds this happened